### PR TITLE
Update behavior for non-glob path strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ globParent('path/+(to|from)'); // 'path'
 globParent('path/*(to|from)'); // 'path'
 globParent('path/@(to|from)'); // 'path'
 globParent('path/**/*'); // 'path'
+
+// if provided a non-glob path, returns the nearest dir
+globParent('path/foo/bar.js'); // 'path/foo'
+globParent('path/foo/'); // 'path/foo'
+globParent('path/foo'); // 'path' (see issue #3 for details)
+
 ```
 
 Change Log

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var path = require('path');
 var isglob = require('is-glob');
 
 module.exports = function globParent(str) {
-	while (isglob(str)) str = path.dirname(str);
+	str += 'a'; // preserves full path in case of trailing path separator
+	do {str = path.dirname(str)} while (isglob(str));
 	return str;
 };

--- a/test.js
+++ b/test.js
@@ -19,4 +19,10 @@ describe('glob-parent', function() {
     assert.equal(gp('path/**/*'), 'path');
     assert.equal(gp('path/**/subdir/foo.*'), 'path');
   });
+
+  it('should return parent dirname from non-glob paths', function() {
+    assert.equal(gp('path/foo/bar.js'), 'path/foo');
+    assert.equal(gp('path/foo/'), 'path/foo');
+    assert.equal(gp('path/foo'), 'path');
+  });
 });


### PR DESCRIPTION
The discussion isn't necessarily settled yet, but just getting the PR started. When landed, should resolve #3.

As of now, this PR would provide parity with glob2base's treatment of regular (non-glob) paths.

/cc @jonschlinkert @robwierzbowski @contra @phated