### PR TITLE
Update is-glob dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/es128/glob-parent",
   "dependencies": {
-    "is-glob": "^2.0.0"
+    "is-glob": "^3.0.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",


### PR DESCRIPTION
Due to https://github.com/jonschlinkert/is-glob/issues/4 and https://github.com/jonschlinkert/is-glob/issues/5 - `is-glob` has been bumped to 3.0

I'm not sure if you want to bump major or something less.  The implementation has gotten more complex but matching has gotten more precise.