### PR TITLE
Windows/backslash auto-fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,33 @@ ensure higher-fidelity glob handling in your library, it is recommended that you
 pre-process your input with [expand-braces] and/or [expand-brackets].
 
 #### Windows
-Backslashes are not valid path separators for globs. Please ensure paths are
-provided with forward-slashes only.
+Backslashes are not valid path separators for globs. If a path with backslashes
+is provided anyway, for simple cases, glob-parent will replace the path
+separator for you and return the non-glob parent path (now with
+forward-slashes, which are still valid as Windows path separators).
+
+This cannot be used in conjunction with escape characters.
+
+```js
+// BAD
+globParent('C:\\Program Files \\(x86\\)\\*.ext') // 'C:/Program Files /(x86/)'
+
+// GOOD
+globParent('C:/Program Files\\(x86\\)/*.ext') // 'C:/Program Files (x86)'
+```
+
+If you are using escape characters for a pattern without path parts (i.e.
+relative to `cwd`), prefix with `./` to avoid confusing glob-parent.
+
+```js
+// BAD
+globParent('foo \\[bar]') // 'foo '
+globParent('foo \\[bar]*') // 'foo '
+
+// GOOD
+globParent('./foo \\[bar]') // 'foo [bar]'
+globParent('./foo \\[bar]*') // '.'
+```
 
 
 Change Log

--- a/index.js
+++ b/index.js
@@ -3,8 +3,12 @@
 var path = require('path');
 var isglob = require('is-glob');
 var pathDirname = require('path-dirname');
+var isWin32 = require('os').platform() === 'win32';
 
 module.exports = function globParent(str) {
+	// flip windows path separators
+	if (isWin32 && str.indexOf('/') < 0) str = str.split('\\').join('/');
+
 	// special case for strings ending in enclosure containing path separator
 	if (/[\{\[].*[\/]*.*[\}\]]$/.test(str)) str += '/';
 

--- a/test.js
+++ b/test.js
@@ -162,3 +162,11 @@ describe('glob2base test patterns', function() {
     assert.equal(gp('ooga/{booga,sooga}/**/dooga/{eooga,fooga}'), 'ooga');
   });
 });
+
+if (require('os').platform() === 'win32') {
+  describe('technically invalid windows globs', function() {
+    it('should manage simple globs with backslash path separator', function() {
+      assert.equal(gp('C:\\path\\*.js'), 'C:/path')
+    });
+  });
+}

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@
 
 var gp = require('./');
 var assert = require('assert');
+var isWin32 = require('os').platform() === 'win32';
 
 describe('glob-parent', function() {
   it('should strip glob magic to return parent path', function() {
@@ -73,13 +74,20 @@ describe('glob-parent', function() {
     assert.equal(gp('path/\\[bar]'), 'path/[bar]');
     assert.equal(gp('[bar]'), '.');
     assert.equal(gp('[bar]/'), '.');
-    assert.equal(gp('\\[bar]'), '[bar]');
-    assert.equal(gp('[bar\\]'), '.');
+    assert.equal(gp('./\\[bar]'), './[bar]');
+    assert.equal(gp('\\[bar]/'), '[bar]');
+    assert.equal(gp('[bar\\]/'), '.');
     assert.equal(gp('path/foo \\[bar]/'), 'path/foo [bar]');
     assert.equal(gp('path/\\{foo,bar}/'), 'path/{foo,bar}');
     assert.equal(gp('\\{foo,bar}/'), '{foo,bar}');
-    assert.equal(gp('\\{foo,bar\\}'), '{foo,bar}');
-    assert.equal(gp('{foo,bar\\}'), '.');
+    assert.equal(gp('\\{foo,bar\\}/'), '{foo,bar}');
+    assert.equal(gp('{foo,bar\\}/'), '.');
+    if (!isWin32) {
+      assert.equal(gp('\\[bar]'), '[bar]');
+      assert.equal(gp('[bar\\]'), '.');
+      assert.equal(gp('\\{foo,bar\\}'), '{foo,bar}');
+      assert.equal(gp('{foo,bar\\}'), '.');
+    }
   });
 
   it('should respect glob enclosures with embedded separators', function() {
@@ -163,7 +171,7 @@ describe('glob2base test patterns', function() {
   });
 });
 
-if (require('os').platform() === 'win32') {
+if (isWin32) {
   describe('technically invalid windows globs', function() {
     it('should manage simple globs with backslash path separator', function() {
       assert.equal(gp('C:\\path\\*.js'), 'C:/path')


### PR DESCRIPTION
Prior to v3, glob-parent didn't have an issue dealing with paths where the glob was part of a backslash-separated path string (it also didn't respect escaping).

This is intended to bring that capability back for basic circumstances and document the caveats. #12 shows why it won't be so simple to just tell users they're doing it wrong. I'd rather opportunistically just fix it when possible.