### PR TITLE
Add `files` to `package.json`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "base",
     "wildcard"
   ],
+  "files": ["index.js"],
   "author": "Elan Shanker (https://github.com/es128)",
   "license": "ISC",
   "bugs": {


### PR DESCRIPTION
Prevents `.travis.yml` and `test.js` from being published to NPM.